### PR TITLE
Handle `channel` correctly

### DIFF
--- a/features/networkManagement.feature
+++ b/features/networkManagement.feature
@@ -6,11 +6,11 @@ Feature: Network management
       Given a connection to the USB stick
 
     Scenario: Network parameters change request
-      When the device "ABCDEF" sends a network parameters change request for channel "0B" and panId "ABCD"
+      When the device "ABCDEF" sends a network parameters change request for channel 11 and panId "ABCD"
       Then the stick receives a request to change the network parameters to channel 11 and panId "ABCD" from device "ABCDEF"
 
     Scenario: Network parameters change request
-      When the device "FEDCBA" sends a network parameters change request for channel "0D" and panId "FFFF"
+      When the device "FEDCBA" sends a network parameters change request for channel 13 and panId "FFFF"
       Then the stick receives a request to change the network parameters to channel 13 and panId "FFFF" from device "FEDCBA"
 
     Scenario: Received wave request
@@ -54,9 +54,9 @@ Feature: Network management
       Then the stick responds negatively
 
     Scenario: Network join request
-      When the device "ABCDEF" sends a network join request for channel "0C" and panId "BEEF" with encryption key "12345678123456781234567812345678"
+      When the device "ABCDEF" sends a network join request for channel 12 and panId "BEEF" with encryption key "12345678123456781234567812345678"
       Then the stick receives a network join request for channel 12 and panId "BEEF" with encryption key "78563412785634127856341278563412" from device "ABCDEF"
 
     Scenario: Network join request
-      When the device "FEDCBA" sends a network join request for channel "0E" and panId "FEED" with encryption key "BEEFBEEF12341234DEADDEAD12341234"
+      When the device "FEDCBA" sends a network join request for channel 14 and panId "FEED" with encryption key "BEEFBEEF12341234DEADDEAD12341234"
       Then the stick receives a network join request for channel 14 and panId "FEED" with encryption key "34123412ADDEADDE34123412EFBEEFBE" from device "FEDCBA"

--- a/features/support/networkManagement.ts
+++ b/features/support/networkManagement.ts
@@ -2,11 +2,11 @@ import {Then, When} from "@cucumber/cucumber";
 import {once} from "node:events";
 import * as assert from "assert";
 
-When('the device {string} sends a network parameters change request for channel {string} and panId {string}', async function (serial, channel, panId) {
+When('the device {string} sends a network parameters change request for channel {int} and panId {string}', async function (serial, channel, panId) {
     this['wmsMock'].mockNetworkParametersChangeBroadcast(serial, channel, panId);
 });
 
-Then('the stick receives a request to change the network parameters to channel {float} and panId {string} from device {string}', async function (channel, panId, serial) {
+Then('the stick receives a request to change the network parameters to channel {int} and panId {string} from device {string}', async function (channel, panId, serial) {
     [this['response']] = await once(this['wms'].frameHandler, '5060');
     assert.strictEqual(this['response'].serial, serial);
     assert.strictEqual(this['response'].channel, channel);
@@ -31,11 +31,11 @@ When('I ask the stick to respond to a scan for panId {string} from device {strin
     }
 });
 
-When('the device {string} sends a network join request for channel {string} and panId {string} with encryption key {string}', async function (serial,  channel, panId, encryptionKey) {
+When('the device {string} sends a network join request for channel {int} and panId {string} with encryption key {string}', async function (serial,  channel, panId, encryptionKey) {
     this['wmsMock'].mockNetworkJoin(serial, channel, panId, encryptionKey);
 });
 
-Then('the stick receives a network join request for channel {float} and panId {string} with encryption key {string} from device {string}', async function (channel, panId, encryptionKey, serial) {
+Then('the stick receives a network join request for channel {int} and panId {string} with encryption key {string} from device {string}', async function (channel, panId, encryptionKey, serial) {
     [this['response']] = await once(this['wms'].frameHandler, '5018');
     assert.strictEqual(this['response'].serial, serial);
     assert.strictEqual(this['response'].channel, channel);

--- a/lib/WaremaWMSFrameHandler.ts
+++ b/lib/WaremaWMSFrameHandler.ts
@@ -118,7 +118,7 @@ class WaremaWMSFrameHandler extends EventEmitter {
                         emitPayload = <WaremaWMSMessageBroadcastNetworkParametersChange>{
                             serial,
                             panId: messagePayload.slice(0, 4),
-                            channel: WaremaWMSUtils.hexToDec(messagePayload.slice(6, 8)),
+                            channel: parseInt(messagePayload.slice(6, 8)),
                         }
                         break
                     case WaremaWMSFrameHandler.MESSAGE_TYPE_BROADCAST_WEATHER:
@@ -151,7 +151,7 @@ class WaremaWMSFrameHandler extends EventEmitter {
                             serial,
                             panId: messagePayload.slice(0, 4),
                             encryptionKey: WaremaWMSUtils.reverseHex(messagePayload.slice(4, 36)),
-                            channel: WaremaWMSUtils.hexToDec(messagePayload.slice(38, 40)),
+                            channel: parseInt(messagePayload.slice(38, 40)),
                         }
                         break
                     case WaremaWMSFrameHandler.MESSAGE_TYPE_DEVICE_MOVE_TO_POSITION_RESPONSE:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wms-js",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Interface to a Warema WMS network using a Warema WMS stick",
   "keywords": [
     "warema",


### PR DESCRIPTION
In the payload, `channel` is already in base 10.